### PR TITLE
expose prometheus metrics + cloudrun compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c83abf9903e1f0ad9973cc4f7b9767fd5a03a583f51a5b7a339e07987cd2724"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "ahash",
+ "base64 0.13.0",
+ "bitflags",
+ "brotli",
+ "bytes",
+ "bytestring",
+ "derive_more",
+ "encoding_rs",
+ "flate2",
+ "futures-core",
+ "h2",
+ "http",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "local-channel",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "sha1",
+ "smallvec",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66ff4d247d2b160861fa2866457e85706833527840e4133f8f49aa423a38799"
+dependencies = [
+ "bytestring",
+ "http",
+ "regex",
+ "serde",
+ "tracing",
+]
+
+[[package]]
 name = "actix-rt"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +111,97 @@ checksum = "7ea16c295198e958ef31930a6ef37d0fb64e9ca3b6116e6b93a8bdae96ee1000"
 dependencies = [
  "futures-core",
  "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da34f8e659ea1b077bb4637948b815cd3768ad5a188fdcd74ff4d84240cd824"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "num_cpus",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
+dependencies = [
+ "futures-core",
+ "paste",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e5ebffd51d50df56a3ae0de0e59487340ca456f05dd0b90c0a7a6dd6a74d31"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "actix-web-codegen",
+ "ahash",
+ "bytes",
+ "bytestring",
+ "cfg-if 1.0.0",
+ "cookie",
+ "derive_more",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2",
+ "time 0.3.9",
+ "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa9362663c8643d67b2d5eafba49e4cb2c8a053a29ed00a0bea121f17c76b13"
+dependencies = [
+ "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -46,6 +214,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
@@ -65,6 +239,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -561,6 +750,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,9 +796,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bytes-utils"
@@ -605,6 +815,15 @@ name = "bytesize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
+name = "bytestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f83e57d9154148e355404702e2694463241880b939570d7c97c014da7a69a1"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
 name = "c2-chacha"
@@ -654,6 +873,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -734,6 +956,17 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "344adc371239ef32293cb1c4fe519592fcf21206c79c02854320afcdf3ab4917"
+dependencies = [
+ "percent-encoding",
+ "time 0.3.9",
+ "version_check",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1091,6 +1324,16 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1476,17 +1719,20 @@ dependencies = [
 name = "indexer-balances"
 version = "0.1.0"
 dependencies = [
+ "actix-web",
  "anyhow",
  "bigdecimal",
  "cached",
  "clap",
  "dotenv",
  "futures",
+ "lazy_static",
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
  "near-lake-framework",
  "near-primitives",
  "num-traits",
+ "prometheus",
  "quote",
  "sqlx",
  "syn",
@@ -1537,6 +1783,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1799,12 @@ checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
@@ -1556,6 +1817,24 @@ name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+
+[[package]]
+name = "local-channel"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f303ec0e94c6c54447f84f3b0ef7af769858a9c4ef56ef2a986d3dcd4c3fc9c"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
 
 [[package]]
 name = "lock_api"
@@ -1617,6 +1896,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -2253,6 +2541,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.1",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "quote"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,6 +2925,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006769ba83e921b3085caa8334186b00cf92b4cb1a6cf4632fbccc8eff5c7549"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2963,7 +3283,14 @@ dependencies = [
  "itoa",
  "libc",
  "num_threads",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"
@@ -3510,4 +3837,33 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.4+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,6 +1739,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -1857,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 dependencies = [
  "regex-automata",
 ]
@@ -2274,9 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"
@@ -2991,9 +2992,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smart-default"
@@ -3435,6 +3436,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9965507e507f12c8901432a33e31131222abac31edd90cabbcf85cf544b7127a"
+dependencies = [
+ "chrono",
+ "crossbeam-channel",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,9 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3467,22 +3479,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.11"
+name = "tracing-serde"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
  "ansi_term",
+ "chrono",
  "lazy_static",
  "matchers",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.9",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ prometheus = "0.13.1"
 quote = "1.0.17"
 actix-web = "=4.0.1"
 lazy_static = "1.4.0"
+aws-types= "0.13.0"
+aws-sdk-s3="0.13.0"
 
 near-jsonrpc-primitives = "0.14.0"
 near-jsonrpc-client = "0.4.0-beta.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,14 @@ futures = "0.3.5"
 num-traits = "0.2.11"
 sqlx = { version = "0.5.13", features = ["runtime-tokio-native-tls", "postgres", "bigdecimal", "json"] }
 syn = "1.0.90"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.8", features = ["sync", "time", "macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1" }
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.11", features = ["fmt", "local-time", "env-filter"] }
+prometheus = "0.13.1"
 quote = "1.0.17"
+actix-web = "=4.0.1"
+lazy_static = "1.4.0"
 
 near-jsonrpc-primitives = "0.14.0"
 near-jsonrpc-client = "0.4.0-beta.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "indexer-balances"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.62.1"
+rust-version = "1.64"
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,24 +8,24 @@ rust-version = "1.64"
 proc-macro = true
 
 [dependencies]
+actix-web = "=4.0.1"
 anyhow = "1.0.51"
 bigdecimal = { version = "0.2", features = ["serde"] }
 cached = "0.23.0"
 clap = { version = "3.2.17", features = ["color", "derive", "env"] }
 dotenv = "0.15.0"
 futures = "0.3.5"
+lazy_static = "1.4.0"
 num-traits = "0.2.11"
+prometheus = "0.13.1"
+quote = "1.0.17"
 sqlx = { version = "0.5.13", features = ["runtime-tokio-native-tls", "postgres", "bigdecimal", "json"] }
 syn = "1.0.90"
 tokio = { version = "1.8", features = ["sync", "time", "macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1" }
 tracing = "0.1.35"
-tracing-subscriber = "0.2.4"
 tracing-appender = "0.1.2"
-prometheus = "0.13.1"
-quote = "1.0.17"
-actix-web = "=4.0.1"
-lazy_static = "1.4.0"
+tracing-subscriber = "0.2.4"
 
 near-jsonrpc-primitives = "0.14.0"
 near-jsonrpc-client = "0.4.0-beta.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,12 @@ syn = "1.0.90"
 tokio = { version = "1.8", features = ["sync", "time", "macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1" }
 tracing = "0.1.35"
-tracing-subscriber = { version = "0.3.11", features = ["fmt", "local-time", "env-filter"] }
+tracing-subscriber = "0.2.4"
+tracing-appender = "0.1.2"
 prometheus = "0.13.1"
 quote = "1.0.17"
 actix-web = "=4.0.1"
 lazy_static = "1.4.0"
-aws-types= "0.13.0"
-aws-sdk-s3="0.13.0"
 
 near-jsonrpc-primitives = "0.14.0"
 near-jsonrpc-client = "0.4.0-beta.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ near-jsonrpc-primitives = "0.14.0"
 near-jsonrpc-client = "0.4.0-beta.0"
 near-lake-framework = "0.5.0"
 near-primitives = "0.14.0"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,3 @@ near-jsonrpc-primitives = "0.14.0"
 near-jsonrpc-client = "0.4.0-beta.0"
 near-lake-framework = "0.5.0"
 near-primitives = "0.14.0"
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.62 AS builder
+FROM rust:1.64 AS builder
 WORKDIR /tmp/
 
 # this build step will cache your dependencies

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -13,21 +13,33 @@ use clap::Parser;
 )]
 pub(crate) struct Opts {
     /// Enabled Indexer for Explorer debug level of logs
-    #[clap(long)]
+    #[clap(long, env)]
     pub debug: bool,
     // todo
     // /// Store initial data from genesis like Accounts, AccessKeys
     // #[clap(long)]
     // pub store_genesis: bool,
     /// AWS S3 bucket name to get the stream from
-    #[clap(long)]
+    #[clap(long, env)]
     pub s3_bucket_name: String,
+    /// AWS Access Key with the rights to read from AWS S3
+    #[clap(long, env)]
+    pub lake_aws_access_key: String,
+    #[clap(long, env)]
+    /// AWS Secret Access Key with the rights to read from AWS S3
+    pub lake_aws_secret_access_key: String,
     /// AWS S3 bucket region
-    #[clap(long)]
+    #[clap(long, env)]
     pub s3_region_name: String,
     /// Block height to start the stream from. If None, start from interruption
-    #[clap(long, short)]
+    #[clap(long, short, env)]
     pub start_block_height: Option<u64>,
-    #[clap(long, short)]
+    #[clap(long, short, env)]
     pub near_archival_rpc_url: String,
+    // Chain ID: testnet or mainnet
+    #[clap(long, env)]
+    pub chain_id: String,
+    /// Port to enable metrics/health service
+    #[clap(long, short, env)]
+    pub port: u16,
 }

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -1,5 +1,7 @@
 use clap::Parser;
 
+use crate::LOGGING_PREFIX;
+
 /// NEAR Indexer for Explorer
 /// Watches for stream of blocks from the chain
 #[derive(Parser, Debug)]
@@ -42,4 +44,45 @@ pub(crate) struct Opts {
     /// Port to enable metrics/health service
     #[clap(long, short, env)]
     pub port: u16,
+}
+
+impl Opts {
+    // Creates AWS Credentials for NEAR Lake
+    fn lake_credentials(&self) -> aws_types::credentials::SharedCredentialsProvider {
+        let provider = aws_types::Credentials::new(
+            self.lake_aws_access_key.clone(),
+            self.lake_aws_secret_access_key.clone(),
+            None,
+            None,
+            "events_indexer",
+        );
+        aws_types::credentials::SharedCredentialsProvider::new(provider)
+    }
+
+    /// Creates AWS Shared Config for NEAR Lake
+    pub fn lake_aws_sdk_config(&self) -> aws_types::sdk_config::SdkConfig {
+        aws_types::sdk_config::SdkConfig::builder()
+            .credentials_provider(self.lake_credentials())
+            .region(aws_types::region::Region::new(self.s3_region_name.clone()))
+            .build()
+    }
+
+    pub async fn get_lake_config(&self, start_block_height: u64) -> near_lake_framework::LakeConfig {
+        let s3_config = aws_sdk_s3::config::Builder::from(&self.lake_aws_sdk_config()).build();
+        let config_builder = near_lake_framework::LakeConfigBuilder::default().s3_config(s3_config);
+
+        tracing::info!(target: LOGGING_PREFIX, "Chain_id: {}", self.chain_id);
+
+        match self.chain_id.as_str() {
+            "mainnet" => config_builder
+                .mainnet()
+                .start_block_height(start_block_height),
+            "testnet" => config_builder
+                .testnet()
+                .start_block_height(start_block_height),
+            _ => panic!("CHAIN_ID is not set to a valid enviornment name. Try `mainnet` or `testnet`")
+        }
+        .build()
+        .expect("Failed to build LakeConfig")
+    }
 }

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -37,9 +37,9 @@ pub(crate) struct Opts {
     pub near_archival_rpc_url: String,
     // Chain ID: testnet or mainnet
     #[clap(long, env)]
-    pub chain_id: String,
-    /// Port to enable metrics/health service
-    #[clap(long, short, env)]
+    pub chain_id: String,    
+    /// Port to enable metrics service
+    #[clap(long, short, env, default_value = "3000")]
     pub port: u16,
 }
 

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -1,9 +1,5 @@
-use std::env;
-
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
-
-use crate::LOGGING_PREFIX;
 
 /// NEAR Indexer for Explorer
 /// Watches for stream of blocks from the chain
@@ -20,26 +16,16 @@ pub(crate) struct Opts {
     /// Enabled Indexer for Explorer debug level of logs
     #[clap(long, env)]
     pub debug: bool,
-    // todo
-    // /// Store initial data from genesis like Accounts, AccessKeys
-    // #[clap(long)]
-    // pub store_genesis: bool,
-    /// AWS S3 bucket name to get the stream from
-    #[clap(long, env)]
-    pub s3_bucket_name: String,
-    /// AWS S3 bucket region
-    #[clap(long, env)]
-    pub s3_region_name: String,
     /// Block height to start the stream from. If None, start from interruption
     #[clap(long, short, env)]
     pub start_block_height: Option<u64>,
     #[clap(long, short, env)]
     pub near_archival_rpc_url: String,
-    // Chain ID: testnet or mainnet
+    // Chain ID: testnet or mainnet, used for NEAR Lake initialization
     #[clap(long, env)]
-    pub chain_id: String,    
+    pub chain_id: String,
     /// Port to enable metrics service
-    #[clap(long, short, env, default_value = "3000")]
+    #[clap(long, short, env, default_value_t = 3000)]
     pub port: u16,
 }
 
@@ -49,13 +35,14 @@ impl Opts {
     pub async fn to_lake_config(&self, start_block_height: u64) -> near_lake_framework::LakeConfig {
         let config_builder = near_lake_framework::LakeConfigBuilder::default();
 
-        tracing::info!(target: LOGGING_PREFIX, "Chain_id: {}", self.chain_id);
+        tracing::info!(target: crate::LOGGING_PREFIX, "CHAIN_ID: {}", self.chain_id);
 
         match self.chain_id.as_str() {
             "mainnet" => config_builder.mainnet(),
             "testnet" => config_builder.testnet(),
-            _ => panic!(
-                "CHAIN_ID is not set to a valid environment name. Try `mainnet` or `testnet`"
+            invalid_chain => panic!(
+                "Invalid CHAIN_ID: `{}`. Try `mainnet` or `testnet`",
+                invalid_chain
             ),
         }
         .start_block_height(start_block_height)
@@ -73,7 +60,7 @@ pub(crate) fn init_tracing(
         env_filter = env_filter.add_directive("near_lake_framework=debug".parse()?);
     }
 
-    if let Ok(rust_log) = env::var("RUST_LOG") {
+    if let Ok(rust_log) = std::env::var("RUST_LOG") {
         if !rust_log.is_empty() {
             for directive in rust_log.split(',').filter_map(|s| match s.parse() {
                 Ok(directive) => Some(directive),

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -52,16 +52,13 @@ impl Opts {
         tracing::info!(target: LOGGING_PREFIX, "Chain_id: {}", self.chain_id);
 
         match self.chain_id.as_str() {
-            "mainnet" => config_builder
-                .mainnet()
-                .start_block_height(start_block_height),
-            "testnet" => config_builder
-                .testnet()
-                .start_block_height(start_block_height),
+            "mainnet" => config_builder.mainnet(),
+            "testnet" => config_builder.testnet(),
             _ => panic!(
-                "CHAIN_ID is not set to a valid enviornment name. Try `mainnet` or `testnet`"
+                "CHAIN_ID is not set to a valid environment name. Try `mainnet` or `testnet`"
             ),
         }
+        .start_block_height(start_block_height)
         .build()
         .expect("Failed to build LakeConfig")
     }

--- a/src/db_adapters/balance_changes.rs
+++ b/src/db_adapters/balance_changes.rs
@@ -605,7 +605,7 @@ async fn get_balance_retriable(
             Ok(res) => return Ok(res),
             Err(err) => {
                 tracing::error!(
-                    target: crate::INDEXER,
+                    target: crate::LOGGING_PREFIX,
                     "Failed to request account view details from RPC for account {}, block_hash {}.{}\n Retrying in {} milliseconds...",
                     account_id.to_string(),
                     block_hash.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,18 +55,11 @@ async fn main() -> anyhow::Result<()> {
         Some(x) => x,
         None => models::start_after_interruption(&pool).await?,
     };
-    let config_builder = near_lake_framework::LakeConfigBuilder::default();
-
-    let config = match opts.chain_id.as_str() {
-        "mainnet" => config_builder.mainnet(),
-        "testnet" => config_builder.testnet(),
-        _ => panic!(),
-    }
-    .start_block_height(start_block_height)
-    .build()?;
 
     init_tracing();
 
+     // create a lake configuration with S3 information passed in as ENV vars
+     let config = opts.get_lake_config(start_block_height).await;
     let (_lake_handle, stream) = near_lake_framework::streamer(config);
 
     // We want to prevent unnecessary RPC queries to find previous balance

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,6 @@ async fn main() -> anyhow::Result<()> {
             }
     }
     });
-    // });
     init_metrics_server().await?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ async fn handle_streamer_message(
     json_rpc_client: &near_jsonrpc_client::JsonRpcClient,
 ) -> anyhow::Result<u64> {
     metrics::BLOCK_PROCESSED_TOTAL.inc();
-    metrics::LATEST_BLOCK_HEIGHT.set(streamer_message.block.header.height.try_into().unwrap());
+    metrics::LATEST_BLOCK_HEIGHT.set(i64::try_from(streamer_message.block.header.height)?);
 
     db_adapters::balance_changes::store_balance_changes(
         pool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@ mod models;
 #[macro_use]
 extern crate lazy_static;
 
-// TODO naming
 pub(crate) const LOGGING_PREFIX: &str = "indexer_balances";
 
 const INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,23 +72,26 @@ async fn main() -> anyhow::Result<()> {
             match handle_message {
                 Ok(block_height) => {
                     let elapsed = time_now.elapsed();
-                    tracing::trace!(
+                    tracing::info!(
+                        target: LOGGING_PREFIX,
                         "Elapsed time spent on block {}: {:.3?}",
                         block_height,
                         elapsed
                     );
                     time_now = std::time::Instant::now();
                 }
-                Err(_e) => {
-                    // return Err(anyhow::Error!(e));
+                Err(e) => {
+                    tracing::error!(target: LOGGING_PREFIX, "Stop indexing due to {}", e);
+                    // we do not catch this error anywhere, this thread is just stopped with error,
+                    // main thread continues serving metrics
+                    anyhow::bail!(e)
                 }
             }
         }
+        Ok(()) // unreachable statement, loop above is endless
     });
 
-    metrics::init_metrics_server().await?;
-
-    Ok(())
+    metrics::init_metrics_server(opts.port).await
 }
 
 async fn handle_streamer_message(
@@ -98,7 +101,8 @@ async fn handle_streamer_message(
     json_rpc_client: &near_jsonrpc_client::JsonRpcClient,
 ) -> anyhow::Result<u64> {
     metrics::BLOCK_PROCESSED_TOTAL.inc();
-    // Prometheus Guage Metric type only supports i64 and f64 types for the time being, so we need to cast the type into i64
+    // Prometheus Gauge Metric type do not support u64
+    // https://github.com/tikv/rust-prometheus/issues/470
     metrics::LATEST_BLOCK_HEIGHT.set(i64::try_from(streamer_message.block.header.height)?);
 
     db_adapters::balance_changes::store_balance_changes(

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,7 @@ async fn handle_streamer_message(
     json_rpc_client: &near_jsonrpc_client::JsonRpcClient,
 ) -> anyhow::Result<u64> {
     metrics::BLOCK_PROCESSED_TOTAL.inc();
+    // Prometheus Guage Metric type only supports i64 and f64 types for the time being, so we need to cast the type into i64
     metrics::LATEST_BLOCK_HEIGHT.set(i64::try_from(streamer_message.block.header.height)?);
 
     db_adapters::balance_changes::store_balance_changes(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 // // TODO cleanup imports in all the files in the end
 use cached::SizedCache;
 use clap::Parser;
+use configs::{init_tracing, Opts};
 use futures::StreamExt;
-use near_primitives::time::Utc;
-use configs::{Opts,init_tracing};
 use metrics_server::{
     init_metrics_server, BLOCK_PROCESSED_TOTAL, LAST_SEEN_BLOCK_HEIGHT, LATEST_BLOCK_TIMESTAMP_DIFF,
 };
 use near_lake_framework::near_indexer_primitives;
+use near_primitives::time::Utc;
 use near_primitives::utils::from_timestamp;
 use tokio::sync::Mutex;
 
@@ -55,9 +55,9 @@ async fn main() -> anyhow::Result<()> {
         None => models::start_after_interruption(&pool).await?,
     };
 
-    init_tracing(opts.debug)?;
+    let _worker_guard = init_tracing(opts.debug)?;
 
-     // create a lake configuration with S3 information passed in as ENV vars
+    // create a lake configuration with S3 information passed in as ENV vars
     let config = opts.to_lake_config(start_block_height).await;
     let (_lake_handle, stream) = near_lake_framework::streamer(config);
 
@@ -88,9 +88,8 @@ async fn main() -> anyhow::Result<()> {
                 Err(_e) => {
                     // return Err(anyhow::Error!(e));
                 }
-
             }
-    }
+        }
     });
     init_metrics_server().await?;
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -22,12 +22,12 @@ pub fn try_create_int_gauge(name: &str, help: &str) -> Result<IntGauge, promethe
 lazy_static! {
     pub static ref BLOCK_PROCESSED_TOTAL: IntCounter = try_create_int_counter(
         "indexer_balances_total_blocks_processed",
-        "Total number of blocks processed"
+        "Total number of blocks processed by indexer regardless of restarts. Used to calculate Block Processing Rate(BPS)"
     )
     .unwrap();
     pub static ref LATEST_BLOCK_HEIGHT: IntGauge = try_create_int_gauge(
         "indexer_balances_latest_block_height",
-        "Number of indexed blocks"
+        "Last seen block height by indexer"
     )
     .unwrap();
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,5 +1,5 @@
 use actix_web::{get, App, HttpServer, Responder};
-use prometheus::{Encoder, Gauge, IntCounter, IntGauge, Opts};
+use prometheus::{Encoder, IntCounter, IntGauge, Opts};
 
 use crate::LOGGING_PREFIX;
 
@@ -19,25 +19,15 @@ pub fn try_create_int_gauge(name: &str, help: &str) -> Result<IntGauge, promethe
     Ok(gauge)
 }
 
-pub fn try_create_gauge(name: &str, help: &str) -> Result<Gauge, prometheus::Error> {
-    let opts = Opts::new(name, help);
-    let gauge = Gauge::with_opts(opts)?;
-    prometheus::register(Box::new(gauge.clone()))?;
-    Ok(gauge)
-}
-
 lazy_static! {
-    pub static ref BLOCK_PROCESSED_TOTAL: IntCounter =
-        try_create_int_counter("total_blocks_processed", "Total number of blocks processed")
-            .unwrap();
-    pub static ref LAST_SEEN_BLOCK_HEIGHT: IntGauge = try_create_int_gauge(
-        "last_seen_block_height",
-        "latest block height seen by indexer."
+    pub static ref BLOCK_PROCESSED_TOTAL: IntCounter = try_create_int_counter(
+        "indexer_balances_total_blocks_processed",
+        "Total number of blocks processed"
     )
     .unwrap();
-    pub static ref LATEST_BLOCK_TIMESTAMP_DIFF: Gauge = try_create_gauge(
-        "latest_block_timestamp",
-        "Difference between latest block timestamp and current time."
+    pub static ref LATEST_BLOCK_HEIGHT: IntGauge = try_create_int_gauge(
+        "indexer_balances_latest_block_height",
+        "Number of indexed blocks"
     )
     .unwrap();
 }
@@ -69,11 +59,6 @@ pub(crate) async fn init_metrics_server() -> anyhow::Result<(), std::io::Error> 
     tracing::info!(
         target: LOGGING_PREFIX,
         "Starting metrics server on http://0.0.0.0:{port}/metrics"
-    );
-
-    tracing::info!(
-        target: LOGGING_PREFIX,
-        "health probe on http://0.0.0.0:{port}/probe"
     );
 
     HttpServer::new(|| App::new().service(get_metrics))

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,16 +3,16 @@ use prometheus::{Encoder, IntCounter, IntGauge, Opts};
 
 use crate::LOGGING_PREFIX;
 
-pub type Result<T, E> = std::result::Result<T, E>;
+type Result<T, E> = std::result::Result<T, E>;
 
-pub fn try_create_int_counter(name: &str, help: &str) -> Result<IntCounter, prometheus::Error> {
+fn try_create_int_counter(name: &str, help: &str) -> Result<IntCounter, prometheus::Error> {
     let opts = Opts::new(name, help);
     let counter = IntCounter::with_opts(opts)?;
     prometheus::register(Box::new(counter.clone()))?;
     Ok(counter)
 }
 
-pub fn try_create_int_gauge(name: &str, help: &str) -> Result<IntGauge, prometheus::Error> {
+fn try_create_int_gauge(name: &str, help: &str) -> Result<IntGauge, prometheus::Error> {
     let opts = Opts::new(name, help);
     let gauge = IntGauge::with_opts(opts)?;
     prometheus::register(Box::new(gauge.clone()))?;
@@ -20,12 +20,12 @@ pub fn try_create_int_gauge(name: &str, help: &str) -> Result<IntGauge, promethe
 }
 
 lazy_static! {
-    pub static ref BLOCK_PROCESSED_TOTAL: IntCounter = try_create_int_counter(
+    pub(crate) static ref BLOCK_PROCESSED_TOTAL: IntCounter = try_create_int_counter(
         "indexer_balances_total_blocks_processed",
         "Total number of blocks processed by indexer regardless of restarts. Used to calculate Block Processing Rate(BPS)"
     )
     .unwrap();
-    pub static ref LATEST_BLOCK_HEIGHT: IntGauge = try_create_int_gauge(
+    pub(crate) static ref LATEST_BLOCK_HEIGHT: IntGauge = try_create_int_gauge(
         "indexer_balances_latest_block_height",
         "Last seen block height by indexer"
     )
@@ -50,12 +50,7 @@ async fn get_metrics() -> impl Responder {
     }
 }
 
-pub(crate) async fn init_metrics_server() -> anyhow::Result<(), std::io::Error> {
-    let port: u16 = std::env::var("PORT")
-        .unwrap_or_else(|_| String::from("3000"))
-        .parse()
-        .expect("Unable to parse `PORT`");
-
+pub(crate) async fn init_metrics_server(port: u16) -> anyhow::Result<()> {
     tracing::info!(
         target: LOGGING_PREFIX,
         "Starting metrics server on http://0.0.0.0:{port}/metrics"
@@ -65,4 +60,5 @@ pub(crate) async fn init_metrics_server() -> anyhow::Result<(), std::io::Error> 
         .bind(("0.0.0.0", port))?
         .run()
         .await
+        .map_err(|e| anyhow::anyhow!("Error while executing HTTP Server: {}", e))
 }

--- a/src/metrics_server.rs
+++ b/src/metrics_server.rs
@@ -60,29 +60,6 @@ async fn get_metrics() -> impl Responder {
     }
 }
 
-#[get("/probe")]
-async fn health_check() -> impl Responder {
-    // shows the last seen block height and difference between last block_timestamp and now
-    let latest_block_timestamp_diff = LATEST_BLOCK_TIMESTAMP_DIFF.get();
-    let last_seen_block_height = LAST_SEEN_BLOCK_HEIGHT.get();
-    let num_blocks_processed = BLOCK_PROCESSED_TOTAL.get();
-
-    let mut res = "".to_owned();
-    if last_seen_block_height != 0 {
-        res.push_str("\n Probe for ");
-        res.push_str(LOGGING_PREFIX);
-        res.push_str("\n Last seen block height: ");
-        res.push_str(last_seen_block_height.to_string().as_str());
-        res.push_str("\n Last seen block timestamp and current time difference (in seconds): ");
-        res.push_str(latest_block_timestamp_diff.to_string().as_str());
-        res.push_str("\n # of Blocks Processed thus far ");
-        res.push_str(num_blocks_processed.to_string().as_str());
-    } else {
-        res.push_str("\n Indexer is starting... ");
-    }
-    res
-}
-
 pub(crate) async fn init_metrics_server() -> anyhow::Result<(), std::io::Error> {
     let port: u16 = std::env::var("PORT")
         .unwrap_or_else(|_| String::from("3000"))
@@ -99,7 +76,7 @@ pub(crate) async fn init_metrics_server() -> anyhow::Result<(), std::io::Error> 
         "health probe on http://0.0.0.0:{port}/probe"
     );
 
-    HttpServer::new(|| App::new().service(get_metrics).service(health_check))
+    HttpServer::new(|| App::new().service(get_metrics))
         .bind(("0.0.0.0", port))?
         .run()
         .await

--- a/src/metrics_server.rs
+++ b/src/metrics_server.rs
@@ -1,0 +1,106 @@
+use actix_web::{get, App, HttpServer, Responder};
+use prometheus::{Encoder, Gauge, IntCounter, IntGauge, Opts};
+
+use crate::LOGGING_PREFIX;
+
+pub type Result<T, E> = std::result::Result<T, E>;
+
+pub fn try_create_int_counter(name: &str, help: &str) -> Result<IntCounter, prometheus::Error> {
+    let opts = Opts::new(name, help);
+    let counter = IntCounter::with_opts(opts)?;
+    prometheus::register(Box::new(counter.clone()))?;
+    Ok(counter)
+}
+
+pub fn try_create_int_gauge(name: &str, help: &str) -> Result<IntGauge, prometheus::Error> {
+    let opts = Opts::new(name, help);
+    let gauge = IntGauge::with_opts(opts)?;
+    prometheus::register(Box::new(gauge.clone()))?;
+    Ok(gauge)
+}
+
+pub fn try_create_gauge(name: &str, help: &str) -> Result<Gauge, prometheus::Error> {
+    let opts = Opts::new(name, help);
+    let gauge = Gauge::with_opts(opts)?;
+    prometheus::register(Box::new(gauge.clone()))?;
+    Ok(gauge)
+}
+
+lazy_static! {
+    pub static ref BLOCK_PROCESSED_TOTAL: IntCounter =
+        try_create_int_counter("total_blocks_processed", "Total number of blocks processed")
+            .unwrap();
+    pub static ref LAST_SEEN_BLOCK_HEIGHT: IntGauge = try_create_int_gauge(
+        "last_seen_block_height",
+        "latest block height seen by indexer."
+    )
+    .unwrap();
+    pub static ref LATEST_BLOCK_TIMESTAMP_DIFF: Gauge = try_create_gauge(
+        "latest_block_timestamp",
+        "Difference between latest block timestamp and current time."
+    )
+    .unwrap();
+}
+
+#[get("/metrics")]
+async fn get_metrics() -> impl Responder {
+    let encoder = prometheus::TextEncoder::new();
+
+    let mut buffer = Vec::new();
+    if let Err(e) = encoder.encode(&prometheus::gather(), &mut buffer) {
+        eprintln!("could not encode metrics: {}", e);
+    };
+
+    match String::from_utf8(buffer.clone()) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("custom metrics could not be from_utf8'd: {}", e);
+            String::default()
+        }
+    }
+}
+
+#[get("/probe")]
+async fn health_check() -> impl Responder {
+    // shows the last seen block height and difference between last block_timestamp and now
+    let latest_block_timestamp_diff = LATEST_BLOCK_TIMESTAMP_DIFF.get();
+    let last_seen_block_height = LAST_SEEN_BLOCK_HEIGHT.get();
+    let num_blocks_processed = BLOCK_PROCESSED_TOTAL.get();
+
+    let mut res = "".to_owned();
+    if last_seen_block_height != 0 {
+        res.push_str("\n Probe for ");
+        res.push_str(LOGGING_PREFIX);
+        res.push_str("\n Last seen block height: ");
+        res.push_str(last_seen_block_height.to_string().as_str());
+        res.push_str("\n Last seen block timestamp and current time difference (in seconds): ");
+        res.push_str(latest_block_timestamp_diff.to_string().as_str());
+        res.push_str("\n # of Blocks Processed thus far ");
+        res.push_str(num_blocks_processed.to_string().as_str());
+    } else {
+        res.push_str("\n Indexer is starting... ");
+    }
+    res
+}
+
+pub(crate) async fn init_metrics_server() -> anyhow::Result<(), std::io::Error> {
+    let port: u16 = std::env::var("PORT")
+        .unwrap_or_else(|_| String::from("3000"))
+        .parse()
+        .expect("Unable to parse `PORT`");
+
+    tracing::info!(
+        target: LOGGING_PREFIX,
+        "Starting metrics server on http://0.0.0.0:{port}/metrics"
+    );
+
+    tracing::info!(
+        target: LOGGING_PREFIX,
+        "health probe on http://0.0.0.0:{port}/probe"
+    );
+
+    HttpServer::new(|| App::new().service(get_metrics).service(health_check))
+        .bind(("0.0.0.0", port))?
+        .run()
+        .await
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -130,12 +130,14 @@ pub(crate) async fn start_after_interruption(
                         LIMIT 1";
 
     let res = select_retry_or_panic(pool, query, &[], 10).await?;
-    Ok(res
+    let latest_block_height = res
         .first()
         .map(|value| value.get::<BigDecimal, _>(0))
         .expect("`START_BLOCK_HEIGHT` should be provided when the DB is empty")
         .to_u64()
-        .expect("height should be positive"))
+        .expect("height should be positive");
+
+    Ok(latest_block_height - 1000)
 }
 
 // Generates `($1, $2), ($3, $4)`

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -138,7 +138,7 @@ pub(crate) async fn start_after_interruption(
         .expect("height should be positive");
 
     // We start reindexing 1000 blocks before the latest block height in the DB.
-    Ok(latest_block_height - 1000)
+    Ok(std::cmp::max(latest_block_height - 1000, 0))
 }
 
 // Generates `($1, $2), ($3, $4)`

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -61,7 +61,7 @@ async fn insert_retry_or_panic<T: SqlxMethods + std::fmt::Debug>(
             Ok(_) => break,
             Err(async_error) => {
                 tracing::error!(
-                         target: crate::INDEXER,
+                         target: crate::LOGGING_PREFIX,
                          "Error occurred during {}:\n{} were not stored. \n{:#?} \n Retrying in {} milliseconds...",
                          async_error,
                          &T::name(),
@@ -106,7 +106,7 @@ pub async fn select_retry_or_panic(
             Err(async_error) => {
                 // todo we print here select with non-filled placeholders. It would be better to get the final select statement here
                 tracing::error!(
-                         target: crate::INDEXER,
+                         target: crate::LOGGING_PREFIX,
                          "Error occurred during {}:\nFailed SELECT:\n{}\n Retrying in {} milliseconds...",
                          async_error,
                     query,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -138,7 +138,11 @@ pub(crate) async fn start_after_interruption(
         .expect("height should be positive");
 
     // We start reindexing 1000 blocks before the latest block height in the DB.
-    Ok(std::cmp::max(latest_block_height - 1000, 0))
+    if latest_block_height < 1000 {
+        Ok(0)
+    } else {
+        Ok(latest_block_height - 1000)
+    }
 }
 
 // Generates `($1, $2), ($3, $4)`

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -137,7 +137,7 @@ pub(crate) async fn start_after_interruption(
         .to_u64()
         .expect("height should be positive");
 
-    // We start from reindexing 1000 blocks before the latest block height in the DB.
+    // We start reindexing 1000 blocks before the latest block height in the DB.
     Ok(latest_block_height - 1000)
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -125,7 +125,7 @@ pub(crate) async fn start_after_interruption(
     pool: &sqlx::Pool<sqlx::Postgres>,
 ) -> anyhow::Result<u64> {
     let query = "SELECT block_height
-                        FROM blocks
+                        FROM near_balance_events
                         ORDER BY block_timestamp desc
                         LIMIT 1";
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -137,6 +137,7 @@ pub(crate) async fn start_after_interruption(
         .to_u64()
         .expect("height should be positive");
 
+    // We start from reindexing 1000 blocks before the latest block height in the DB.
     Ok(latest_block_height - 1000)
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -130,14 +130,12 @@ pub(crate) async fn start_after_interruption(
                         LIMIT 1";
 
     let res = select_retry_or_panic(pool, query, &[], 10).await?;
-    let latest_block_height_in_db = res
+    Ok(res
         .first()
-        .ok_or_else(|| {
-            anyhow::format_err!("START_BLOCK_HEIGHT should be provided on indexer's first launch")
-        })
-        .map(|value| value.get::<BigDecimal, _>(0))?;
-    
-    Ok(latest_block_height_in_db.to_u64().expect("height should be positive"))
+        .map(|value| value.get::<BigDecimal, _>(0))
+        .expect("`START_BLOCK_HEIGHT` should be provided when the DB is empty")
+        .to_u64()
+        .expect("height should be positive"))
 }
 
 // Generates `($1, $2), ($3, $4)`


### PR DESCRIPTION
This PR enables us to look into the performance of the micro-indexers and makes them compatible with GCP's Cloud Run service. 

- [X] Works in Cloudrun
- [X] Prometheus metrics `/metrics`
         - Block Processing Speed
         - Latest Block Height indexed by Indexer
- [X] Nonblocking JSON logs